### PR TITLE
__filename is different from process.argv 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ notifications:
 node_js:
   - "5"
   - "4"
-  - "0.12"

--- a/bin/per-env
+++ b/bin/per-env
@@ -29,7 +29,7 @@ var args = [
   script
 ].concat(
   // Extra arguments after "per-env"
-  process.argv.slice(process.argv.indexOf(__filename) + 1)
+  process.argv.slice(2)
 );
 
 var options = {


### PR DESCRIPTION
`__filename` is `<repo>/node_modules/per-env/bin/per-env`
2nd arg in `process.argv` is `<repo>/node_modules/.bin/per-env`

Results are that `<nodepath>/node" "<repo>/node_modules/.bin/per-env"` is added to the end of the command