### PR TITLE
Blank string load default "development"

### DIFF
--- a/bin/per-env
+++ b/bin/per-env
@@ -2,20 +2,20 @@
 
 var pkg = require(process.cwd() + "/package.json");
 var spawnSync = require("child_process").spawnSync;
-
-// Default to "development"
-var NODE_ENV = process.env.NODE_ENV || "development";
+var NODE_ENV = process.env.NODE_ENV || "";
 
 var env = Object.assign(
   {},
   // Default NODE_ENV
-  { NODE_ENV: NODE_ENV},
+  { NODE_ENV: NODE_ENV },
   // Override with package.json custom env variables
   (pkg && pkg["per-env"] && pkg["per-env"][NODE_ENV]) || {},
-
   // Explicit env takes precedence
   process.env
 );
+
+// Default blank to "development"
+if (env.NODE_ENV.trim() === "") env.NODE_ENV = "development"
 
 var command = "npm";
 


### PR DESCRIPTION
In some cases, such as Docker, environment variables receive the value empty string. It is preferable to set "development"
