### PR TITLE
Pass additional args (#6)

### DIFF
--- a/bin/per-env
+++ b/bin/per-env
@@ -28,6 +28,7 @@ var args = [
   "run",
   script
 ].concat(
+  "--",
   // Extra arguments after "per-env"
   process.argv.slice(2)
 );


### PR DESCRIPTION
I believe the issue is that for the following package.json:
```
{
  "test": "per-env",
  "test:development": "mocha --watch",
  "test:test": "mocha"
}
```
`npm test -- --grep api` is running `npm test:development --grep api` when it should be running `npm test:development -- --grep api`.