### PR TITLE
give warn and exit with 0 if the script doesn't exist

### DIFF
--- a/bin/per-env
+++ b/bin/per-env
@@ -24,6 +24,12 @@ var script = [
   env.NODE_ENV,
 ].join(":"); // e.g. "start:development"
 
+// Check If the script exists
+if (!pkg || !pkg.scripts || !pkg.scripts[script]) {
+  console.warn('Cannot find the script:' + script);
+  process.exit(0);
+}
+
 var args = [
   "run",
   script

--- a/bin/per-env
+++ b/bin/per-env
@@ -26,7 +26,7 @@ var script = [
 
 // Check If the script exists
 if (!pkg || !pkg.scripts || !pkg.scripts[script]) {
-  console.warn('Cannot find the script:' + script);
+  console.warn('[per-env] [Warning] Cannot find the script: ' + script);
   process.exit(0);
 }
 


### PR DESCRIPTION
Hello! Thank for your nice module.

This is my actual scenario;
I want to run prestart script just for `development` only and I don't want to specify `prestart:production` or `prestart:stage` or something with empty script string. but for now, per-env tries the script with unspecified env and it makes missing script error.

So I think it would be better that it doesn't try the script of unspecified env and just give warning.
The warning sentence in my code is just suggestion. I have no special idea for now.