### PR TITLE
Set default env variables

### DIFF
--- a/bin/per-env
+++ b/bin/per-env
@@ -7,10 +7,10 @@ var spawnSync = require("child_process").spawnSync;
 var NODE_ENV = process.env.NODE_ENV || "development";
 
 var env = Object.assign(
+  // Default NODE_ENV
+  {NODE_ENV: NODE_ENV},
   // Set default env variables
   (pkg && pkg["per-env"] && pkg["per-env"]["default"]) || {},
-  // Default NODE_ENV
-  { NODE_ENV: NODE_ENV},
   // Override with package.json custom env variables
   (pkg && pkg["per-env"] && pkg["per-env"][NODE_ENV]) || {},
 

--- a/bin/per-env
+++ b/bin/per-env
@@ -7,7 +7,8 @@ var spawnSync = require("child_process").spawnSync;
 var NODE_ENV = process.env.NODE_ENV || "development";
 
 var env = Object.assign(
-  {},
+  // Set default env variables
+  (pkg && pkg["per-env"] && pkg["per-env"]["default"]) || {},
   // Default NODE_ENV
   { NODE_ENV: NODE_ENV},
   // Override with package.json custom env variables


### PR DESCRIPTION
As per issue #13, now we could do:

```
{
  "per-env": {
    "default": {
      "NODE_ENV": "production",
      "DATABASE": "hogwarts",
      "DATABASE_USER": "hermione",
      "DATABASE_PWD": "caput_draconis"
    },
    "production": {
      "DATABASE": "hogwarts-prod",
      "DATABASE_USER": "dumbledore",
      "DATABASE_PWD": "sherbet_lemon"
    }
  },
  "scripts": {
    "start": "per-env",
    "start:production": "node src/index.js"
  }
}
``` 

This way, all environments except `production` will have the the same `DATABASE`, `DATABASE_USER` and `DATABASE_PWD`. Also, the default `NODE_ENV` can be set as well.