### PR TITLE
Preserve flags while redirecting script

### DIFF
--- a/bin/per-env
+++ b/bin/per-env
@@ -28,6 +28,7 @@ var args = [
   "run",
   script
 ].concat(
+  "--",
   // Extra arguments after "per-env"
   process.argv.slice(2)
 );


### PR DESCRIPTION
This prevent flags being consumed by `npm run` while redirecting. Maybe fix #6.
 
Here are some test:
```sh
$ npm run t --x
[ '/usr/bin/node', '/tmp/hello/t.js' ] // process.argv

$ npm run t -- --x
[ '/usr/bin/node', '/tmp/hello/t.js', '--x' ] // process.argv

$ npm run t -- hhh --a
[ '/usr/bin/node', '/tmp/hello/t.js', 'a', '--x' ] // process.argv

$ npm run t a --x -- b --y --z
[ '/usr/bin/node', '/tmp/hello/t.js', 'a', 'b', '--y', '--z' ] // process.argv
```